### PR TITLE
Added support for limit, sort, skip, and findOne

### DIFF
--- a/src/MongoCollection.php
+++ b/src/MongoCollection.php
@@ -63,6 +63,18 @@ class MongoCollection
     }
 
     /**
+     * @param array $query
+     * @param array $fields
+     * @return array or null
+     */
+    public function findOne(array $query = [], array $fields = [])
+    {
+        $cur = $this->find($query, $fields)->limit(1);
+        return ($cur->valid()) ? $cur->current() : null;
+    }
+
+
+    /**
      * Drop the current collection
      * @returns array
      */


### PR DESCRIPTION
Basic support for the following:
`$collection->findOne([ 'something'=>'that-is' ]);`
...returns null or document.

`$cursor = $collection->find()->sort([ 'name'=>-1 ])->skip(50)->limit(5);`
...should work now.

Take note that `fetchDocuments()` is now lazy-called on first valid(), current(), etc.
