### PR TITLE
fix pids over int16 in OSX

### DIFF
--- a/src/MongoId.php
+++ b/src/MongoId.php
@@ -34,9 +34,15 @@ class MongoId
         if (null === self::$refInc) {
            self::$refInc = (int)mt_rand(0, pow(2, 24));
         }
+        
         $this->timestamp = time();
-        $this->pid = getmypid();
         $this->inc = self::$refInc++;
+        $this->pid = getmypid();
+
+        if ($this->pid > 32768) {
+            $this->pid = $this->pid - 65536;
+        }
+
         return $this->assembleId();
     }
 

--- a/test/MongoTest/MongoIdTest.php
+++ b/test/MongoTest/MongoIdTest.php
@@ -2,7 +2,7 @@
 
 class MongoIdTest extends PHPUnit_Framework_TestCase
 {
-    function testGenerateId()
+    public function testGenerateId()
     {
         $id = new MongoId();
         $this->assertInternalType('string', $id->__toString());
@@ -10,13 +10,13 @@ class MongoIdTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(24, strlen($id));
     }
 
-    function testCustomId()
+    public function testCustomId()
     {
         $id = new MongoId('0123456789abcdef01234567');
         $this->assertEquals('0123456789abcdef01234567', $id);
     }
 
-    function testDisassemble()
+    public function testDisassemble()
     {
         $id = new MongoId('5307236762e2167d348b456b');
         $this->assertEquals(1392976743, $id->getTimestamp());
@@ -24,7 +24,7 @@ class MongoIdTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(9127275, $id->getInc());
     }
 
-    function testAssemble()
+    public function testAssemble()
     {
         $id1 = MongoId::__set_state([
             'timestamp' => 1234567890,
@@ -40,6 +40,19 @@ class MongoIdTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('0897ac', substr($id2, 8, 6));
         $this->assertEquals(314, $id2->getPid());
         $this->assertEquals(5555, $id2->getInc());
+    }
+
+    /** 
+     * The pid cannnot be injected so if the run process is under Int16 
+     * this tests dont have sense. In Linux the max value is 32768, but
+     * on OSX is 99998
+     */
+    public function testPidGenerationInt16InOSX()
+    {
+        $original = new MongoId();
+        $build = new MongoId((string) $original);
+
+        $this->assertEquals($original, $build);
     }
 }
  


### PR DESCRIPTION
This fix is related to #18 issue.
