### PR TITLE
Allow use valid ipv4 address in connection url

### DIFF
--- a/tests/Mongofill/Tests/MongoClientTest.php
+++ b/tests/Mongofill/Tests/MongoClientTest.php
@@ -24,6 +24,12 @@ class MongoClientTest extends TestCase
         $this->assertInstanceOf('Mongofill\Protocol', $m->_getProtocol());
     }
 
+    function testIpv4Address()
+    {
+        $m = new MongoClient('mongodb://127.0.0.1:27017', []);
+        $this->assertInstanceOf('Mongofill\Protocol', $m->_getProtocol());
+    }
+
     function testKillCursor()
     {
         $data = [


### PR DESCRIPTION
Using ipv4 address in connection string is valid
(eg.: 'mongodb://127.0.0.1:27017)
