### PR TITLE
MongoClient::killCursor()

### DIFF
--- a/src/MongoClient.php
+++ b/src/MongoClient.php
@@ -265,7 +265,18 @@ class MongoClient
      */
     public function killCursor($serverHash, $id)
     {
-        throw new Exception('Not Implemented');
+        // since we currently support just single server connection,
+        // the $serverHash arg is ignored
+
+        if ($id instanceof MongoInt64) {
+            $id = $id->value;
+        } elseif (!is_numeric($id)) {
+            return false;
+        }
+
+        $this->protocol->opKillCursors([ (int)$id ], [], MongoCursor::$timeout);
+
+        return true;
     }
 
     /**

--- a/src/MongoCursor.php
+++ b/src/MongoCursor.php
@@ -684,4 +684,14 @@ class MongoCursor implements Iterator
         $this->currKey = 0;
         $this->end = false;
     }
+
+    /**
+     * INTERNAL: Gets the cursor id (not part of the original driver)
+     *
+     * @return int|null
+     */
+    public function _getCursorId()
+    {
+        return $this->cursorId;
+    }
 }

--- a/src/Mongofill/Protocol.php
+++ b/src/Mongofill/Protocol.php
@@ -117,6 +117,25 @@ class Protocol
         return $this->putReadMessage(self::OP_GET_MORE, $data, $timeout);
     }
 
+    public function opKillCursors(
+        array $cursors,
+        array $options,
+        $timeout
+    )
+    {
+        $binCursors = array_reduce(
+            $cursors,
+            function($bin, $cursor) {
+                return $bin .= Util::encodeInt64($cursor);
+            },
+            ''
+        );
+
+        $data = pack('VVa*', 0, count($cursors), $binCursors);
+
+        return $this->putWriteMessage(self::OP_KILL_CURSORS, $data, $options, $timeout);
+    }
+
     protected function putWriteMessage($opCode, $opData, array $options, $timeout)
     {
         return $this->socket->putWriteMessage($opCode, $opData, $options, $timeout);

--- a/tests/Mongofill/Tests/MongoClientTest.php
+++ b/tests/Mongofill/Tests/MongoClientTest.php
@@ -26,7 +26,27 @@ class MongoClientTest extends TestCase
 
     function testKillCursor()
     {
-        $cur = $this->getTestDB()->selectCollection(__FUNCTION__)->find();
-        $cur->get
+        $data = [
+            [ 'A' ],
+            [ 'B' ],
+            [ 'C' ],
+            [ 'D' ],
+        ];
+        $col = $this->getTestDB()->selectCollection(__FUNCTION__);
+
+        $col->batchInsert($data);
+
+        $cur = $col->find();
+        $cur->batchSize(2);
+        $cur->limit(4);
+
+        $cur->next();
+        $cur->current();
+        $this->assertNotEquals(0, $cur->_getCursorId());
+
+        $this->getTestClient()->killCursor('foo', $cur->_getCursorId());
+
+        $cur->next();
+        $this->assertNull($cur->current());
     }
 }


### PR DESCRIPTION
Hi, I'm back :) There is my killCursor method implementation, we should now use it to "garbage collect" opened cursors internally in MongoCursor class, like the original driver does. Unfortunately, this will probably make the benchmarks slower, i think.
