### PR TITLE
COMPAT: Make findAndModify return an empty array when no match found.

### DIFF
--- a/src/MongoCollection.php
+++ b/src/MongoCollection.php
@@ -189,7 +189,7 @@ class MongoCollection
         if (isset($result['value'])) {
             return $result['value'];
         }
-        return null;
+        return [];
     }
 
     /**

--- a/tests/Mongofill/Tests/MongoCollectionTest.php
+++ b/tests/Mongofill/Tests/MongoCollectionTest.php
@@ -368,12 +368,14 @@ class MongoCollectionTest extends TestCase
     public function testFindAndModify()
     {
         $coll = $this->getTestDB()->selectCollection(__FUNCTION__);
-        $coll->findAndModify(
+        $record = $coll->findAndModify(
             ['name'=>'bar'],
             ['$inc' => ['value' => 1]],
             null,
             ['new' => false, 'upsert' => true]
         );
+
+        $this->assertSame([], $record);
 
         $result = iterator_to_array($coll->find());
         $this->assertCount(1, $result);


### PR DESCRIPTION
The pecl extension for mongo returns an empty array when the find does not match anything, not null.
