### PR TITLE
Provide ext-mongo in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
             "homepage": "https://github.com/mongofill/mongofill/graphs/contributors"
         }
     ],
+    "provide": {
+        "ext-mongo": "*"
+    },
     "require-dev": {
         "athletic/athletic": "dev-master"
     },


### PR DESCRIPTION
Hi,

`Doctrine mongodb` requires the `ext-mongo` extension (see https://github.com/doctrine/mongodb/blob/master/composer.json#L16)

This PR fixes this requirement. However I'm not sure if I should use a specific version instead of `"*"`.
