### PR TITLE
Fix #48 - catch case where count is 0

### DIFF
--- a/src/MongoCursor.php
+++ b/src/MongoCursor.php
@@ -681,6 +681,16 @@ class MongoCursor implements Iterator
      */
     public function valid()
     {
+        // Issue #48 - special case where result set is count 0
+	if (!$this->end && $this->currKey === 0) {
+            $this->doQuery();
+            $this->fetchMoreDocumentsIfNeeded();
+
+            if (!isset($this->documents[$this->currKey])) {
+               return false;
+            }
+        }
+
         return !$this->end;
     }
 


### PR DESCRIPTION
We were running into this issue and noticed that our foreach loops were causing extra "null" values to get inserted into our data structures.

This patch seems to fix the problem - basically do most of a "current()" call when $currKey is 0 just to make sure that it's not a count == 0 result.

If it's a count == 0 result, then valid() has to return false to make sure the iterator wont run.
