### PR TITLE
Parsing of connection string URI

### DIFF
--- a/src/MongoClient.php
+++ b/src/MongoClient.php
@@ -11,6 +11,7 @@ class MongoClient
     const VERSION = '1.3.0-mongofill';
     const DEFAULT_HOST = 'localhost';
     const DEFAULT_PORT = 27017;
+    const DEFAULT_DATABASE = 'admin';
     const RP_PRIMARY   = 'primary';
     const RP_PRIMARY_PREFERRED = 'primaryPreferred';
     const RP_SECONDARY = 'secondary';
@@ -176,10 +177,6 @@ class MongoClient
 
         if ($nsPart != null && strlen($nsPart) != 0) {// database
             $this->database = $nsPart;
-        } else {
-            if ($this->username != null) {
-                $this->database = "admin";
-            }
         }
 
         $uri_options = [];
@@ -189,7 +186,7 @@ class MongoClient
             $idx = strrpos($part, '=');
 
             if ($idx !== false) {
-                $key = strtolower(substr($part, 0, $idx));
+                $key = substr($part, 0, $idx);
                 $value = substr($part, $idx + 1);
 
                 $uri_options[$key] = $value;
@@ -222,6 +219,10 @@ class MongoClient
 
         if (array_key_exists('db', $this->options)) {
             $this->database = $this->options['db'];
+        }
+
+        if ($this->database == null && $this->username != null) {
+            $this->database = self::DEFAULT_DATABASE;
         }
 
         $idx = strrpos($this->hosts[0], ':');
@@ -313,6 +314,44 @@ class MongoClient
         }
 
         return $this->protocol;
+    }
+
+    /**
+     * @return string - The name of the database to authenticate
+     */
+    public function _getAuthenticationDatabase()
+    {
+        return $this->database;
+    }
+
+    /**
+     * @return string - The username for authentication
+     */
+    public function _getAuthenticationUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @return string - The password for authentication
+     */
+    public function _getAuthenticationPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $name - The option name.
+     *
+     * @return string - The option value
+     */
+    public function _getOption($name)
+    {
+        if (array_key_exists($name, $this->options)) {
+            return $this->options[$name];
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Mongofill/Tests/MongoClientTest.php
+++ b/tests/Mongofill/Tests/MongoClientTest.php
@@ -6,6 +6,58 @@ use MongoClient;
 
 class MongoClientTest extends TestCase
 {
+    /**
+     * @expectedException MongoConnectionException
+     */
+    public function testInvalidURI()
+    {
+        $m = new MongoClient('foo', ['connect' => false]);
+    }
+
+    /**
+     * @expectedException MongoConnectionException
+     */
+    public function testMissingTrailingSlash()
+    {
+        $m = new MongoClient('mongodb://foo?wtimeoutms=500', ['connect' => false]);
+    }
+
+    public function testServerSimple()
+    {
+        $m = new MongoClient('mongodb://foo', ['connect' => false]);
+        $this->assertEquals('mongodb://foo:'.MongoClient::DEFAULT_PORT, $m->server);
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testMultipleServersNotSupported()
+    {
+        $m = new MongoClient('mongodb://foo,bar:123,zee', ['connect' => false]);
+    }
+
+    public function testServerAuthenticationDefaultDatabase()
+    {
+        $m = new MongoClient('mongodb://user:pass@foo:123', ['connect' => false]);
+        $this->assertEquals('user', $m->_getAuthenticationUsername());
+        $this->assertEquals('pass', $m->_getAuthenticationPassword());
+        $this->assertEquals(MongoClient::DEFAULT_DATABASE, $m->_getAuthenticationDatabase());
+    }
+
+    public function testServerAuthenticationWithDatabase()
+    {
+        $m = new MongoClient('mongodb://user:pass@foo:123/mydb', ['connect' => false]);
+        $this->assertEquals('user', $m->_getAuthenticationUsername());
+        $this->assertEquals('pass', $m->_getAuthenticationPassword());
+        $this->assertEquals('mydb', $m->_getAuthenticationDatabase());
+    }
+
+    public function testServerOptionsInURI()
+    {
+        $m = new MongoClient('mongodb://foo/?connectTimeoutMS=500', ['connect' => false]);
+        $this->assertEquals('500', $m->_getOption('connectTimeoutMS'));
+    }
+
     public function testServerOptions()
     {
         $m = new MongoClient('mongodb://foo', ['port' => 123, 'connect' => false]);


### PR DESCRIPTION
Adds support for mongo's connection string uri as described in http://docs.mongodb.org/manual/reference/connection-string/.
(based on https://github.com/mongodb/mongo-java-driver/blob/master/src/main/com/mongodb/MongoClientURI.java)

Additionally authenticates the user on connect if credentials were provided (MONGODB-CR).

Pretty much ignores everything else. Throws 'Not Implemented' exception if multiple hosts are specified.
