### PR TITLE
Added MongoCollection::ASCENDING + MongoCollection::DESCENDING constants

### DIFF
--- a/src/MongoCollection.php
+++ b/src/MongoCollection.php
@@ -7,6 +7,9 @@ use Mongofill\Protocol;
  */
 class MongoCollection
 {
+    const ASCENDING = 1;
+    const DESCENDING = -1;
+
     /**
      * @var string
      */

--- a/tests/Mongofill/Tests/MongoCollectionTest.php
+++ b/tests/Mongofill/Tests/MongoCollectionTest.php
@@ -516,6 +516,12 @@ class MongoCollectionTest extends TestCase
         $this->assertCount(2, $results);
     }
 
+    public function testSortConstantsExist()
+    {
+        $this->assertSame(1,  MongoCollection::ASCENDING);
+        $this->assertSame(-1, MongoCollection::DESCENDING);
+    }
+
 }
 
 class MongoCollectionWrapper extends MongoCollection {


### PR DESCRIPTION
The `MongoCollection` class is missing the `ASCENDING` + `DESCENDING` constants, which is causing some existing code to break. This very simple PR adds the constants and ensures they have the correct values.
