### PR TITLE
Make all exception classes extend MongoException

### DIFF
--- a/src/MongoConnectionException.php
+++ b/src/MongoConnectionException.php
@@ -3,6 +3,6 @@
 /**
  * Thrown when the driver fails to connect to the database.
  */
-class MongoConnectionException extends Exception
+class MongoConnectionException extends MongoException
 {
 }

--- a/src/MongoCursorException.php
+++ b/src/MongoCursorException.php
@@ -3,7 +3,7 @@
 /**
  * Caused by accessing a cursor incorrectly or a error receiving a reply.
  */
-class MongoCursorException extends Exception
+class MongoCursorException extends MongoException
 {
     /**
      * The hostname of the server that encountered the error

--- a/src/MongoCursorTimeoutException.php
+++ b/src/MongoCursorTimeoutException.php
@@ -5,6 +5,6 @@
  * this exception is thrown by calling MongoCursor::timeout() on the cursor or
  * setting MongoCursor::$timeout.
  */
-class MongoCursorTimeoutException extends Exception
+class MongoCursorTimeoutException extends MongoException
 {
 }

--- a/src/MongoGridFSException.php
+++ b/src/MongoGridFSException.php
@@ -4,6 +4,6 @@
  * Thrown when there are errors reading or writing files to or from the
  * database.
  */
-class MongoGridFSException extends Exception
+class MongoGridFSException extends MongoException
 {
 }

--- a/src/MongoResultException.php
+++ b/src/MongoResultException.php
@@ -5,7 +5,7 @@
  * MongoCollection::findAndModify) in the event of failure. The original
  * result document is available through MongoResultException::getDocument.
  */
-class MongoResultException extends Exception
+class MongoResultException extends MongoException
 {
     /**
      * Retrieve the full result document


### PR DESCRIPTION
In the official Mongo client, when for example a MongoConnectionException is thrown, you are able to catch it with a MongoException. mongofill does not currently match this behaviour.

This PR makes all exception classes extend MongoException.
