### PR TITLE
Use flag SLAVE_OK to count results

### DIFF
--- a/src/MongoCursor.php
+++ b/src/MongoCursor.php
@@ -314,7 +314,7 @@ class MongoCursor implements Iterator
 
         $response = $this->client->_getReadProtocol($this->readPreference)->opQuery(
             $ns[0] . '.$cmd',
-            $query, 0, -1, 0,
+            $query, 0, -1, $this->flags | Mongofill\Protocol::QF_SLAVE_OK,
             $this->queryTimeout
         );
 


### PR DESCRIPTION
The count function is not using the flag SLAVE_OK like in other functions and breaks while querying on secondary.