### PR TITLE
Fix notice "Undefined index: readPreferenceTags" in \MongoClient

### DIFF
--- a/src/MongoClient.php
+++ b/src/MongoClient.php
@@ -254,8 +254,11 @@ class MongoClient
         if (isset($this->options['replicaSet'])) {
             $this->replSet = $this->options['replicaSet'];
         }
+
         if (isset($this->options['readPreference'])) {
-            $this->setReadPreference($this->options['readPreference'], $this->options['readPreferenceTags']);
+            $tags = isset($this->options['readPreferenceTags']) ? $this->options['readPreferenceTags'] : null;
+
+            $this->setReadPreference($this->options['readPreference'], $tags);
         }
 
         if (!isset($this->options['connect']) || $this->options['connect'] === true) {

--- a/src/MongoId.php
+++ b/src/MongoId.php
@@ -5,7 +5,7 @@
  * into the database without an _id field, an _id field will be added to it
  * with a MongoId instance as its value.
  */
-class MongoId
+class MongoId implements \Serializable
 {
     /**
      * @var string
@@ -60,6 +60,26 @@ class MongoId
 
         $this->id = $id;
         $this->{'$id'} = $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return $this->__toString();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        $this->id = $serialized;
     }
 
     private function generateId()


### PR DESCRIPTION
Hi.
There was no additional check for existence of a key "readPreferenceTags" in connection options.