### PR TITLE
switched out SOL_TCP constant

### DIFF
--- a/src/Mongofill/Socket.php
+++ b/src/Mongofill/Socket.php
@@ -57,7 +57,7 @@ class Socket
                 ));
             }
         } else {
-            $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+            $this->socket = socket_create(AF_INET, SOCK_STREAM, getprotobyname("tcp"));
             if (!$this->socket) {
                 throw new MongoConnectionException(sprintf(
                     'error creating socket: %s',


### PR DESCRIPTION
FreeBSD does not define the SOL_TCP constant, so to add support for BSD, I am proposing this simple change. SOL_TCP simply needs to be switched to the function call getprotobyname("tcp"), which works across BSD as well as other *nix derivatives.

Fixes issue gh-76