### PR TITLE
Avoid caching the wrong protocol before we have replSetStatus

### DIFF
--- a/src/MongoClient.php
+++ b/src/MongoClient.php
@@ -452,7 +452,7 @@ class MongoClient
     public function _getReadProtocol(array $readPreference)
     {
         $this->connect();
-        if (!$this->replSet) {
+        if (!$this->replSet || !$this->replSetStatus) {
             return reset($this->protocols);
         }
 


### PR DESCRIPTION
Without this we end up ignoring our `$readPreference` by caching before we even know who the master is.