### PR TITLE
Distinct Command Broken in New Mongo Versions

### DIFF
--- a/src/MongoCollection.php
+++ b/src/MongoCollection.php
@@ -650,8 +650,11 @@ class MongoCollection
         $cmd = [
             'distinct' => $this->name,
             'key' => $key,
-            'query' => $query
         ];
+
+        if (!empty($query)) {
+            $cmd['query'] = $query;
+        }
 
         $results = $this->db->command($cmd);
         if (!isset($results['values'])) {


### PR DESCRIPTION
The Distinct command used to accept an array for its query parameter, but that has changed. Unfortunately, an empty array will compile to an array in BSON rather than an empty object, so an empty $query parameter breaks. This patches the driver so that if $query is not defined, then it does not include it at all.

Fixes tests that were breaking against MongoDB 3.0.4.

The PHP driver had the same issue and implemented the same fix: https://github.com/mongodb/mongo-php-driver/commit/9afd1444a3b91977aebd8fb8a3a83cedf6f4a56f