### PR TITLE
Readpref fixes

### DIFF
--- a/src/MongoCollection.php
+++ b/src/MongoCollection.php
@@ -146,7 +146,12 @@ class MongoCollection
      */
     public function find(array $query = [], array $fields = [])
     {
-        return new MongoCursor($this->client, $this->fqn, $query, $fields);
+        $cursor =  new MongoCursor($this->client, $this->fqn, $query, $fields);
+        $rp = $this->readPreference['type'];
+        $tags = (isset($this->readPreference['tagsets'])) ? $this->readPreference['tagsets'] : [];
+        // Ensure any read preference overrides are cascaded
+        $cursor->setReadPreference($rp, $tags);
+        return $cursor;
     }
 
     /**

--- a/tests/Mongofill/Tests/Integration/ReplSet/MongoClientTest.php
+++ b/tests/Mongofill/Tests/Integration/ReplSet/MongoClientTest.php
@@ -66,6 +66,10 @@ class MongoClientTest extends TestCase
         $this->assertEquals(static::$primary_server, $protocol->getServerHash());
     }
 
+    // TODO: Due to the complex nature of logic for read preference cascading, these tests need to
+    //       be altered to do actual queries to ensure the proper read preference is used at the
+    //       cursor level.
+    
     public function testReadPreferencePrimary()
     {
         $m = $this->getTestClient(['readPreference' => MongoClient::RP_PRIMARY]);


### PR DESCRIPTION
This fixes an issue with read preference cascading/overriding that I introduced in my last changeset. While the tests for MongoClient worked, the "temporary" RP_PRIMARY read preference that we set during replSet initialization ended up hanging around for active cursors causing an issue. This fixes that by

1. Allowing read preference overrides from MongoDB to cascade to MongoCollection
2. Only overriding the read preference on the MongoDB object during replSet initialization