### PR TITLE
Update the logic of MongoId::isValid

### DIFF
--- a/src/MongoId.php
+++ b/src/MongoId.php
@@ -180,11 +180,13 @@ class MongoId implements \Serializable
      */
     public static function isValid($id)
     {
-        if (!is_string($id)) {
+        if (get_class($id) == 'MongoId') {
+            return true;
+        } else if (!is_string($id)) {
             return false;
         }
 
-        return preg_match('/[0-9a-fA-F]{24}/', $id);
+        return preg_match('/^[0-9a-fA-F]{24}$/', $id);
     }
 
     /**


### PR DESCRIPTION
Update the logic of MongoId::isValid to be the same as described in PHP official document.
"Returns TRUE if value is a MongoId instance or a string consisting of exactly 24 hexadecimal characters; otherwise, FALSE is returned."