### PR TITLE
Fix: MongoCursor returning a null value in an empty cursor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fiskie/mongofill",
+    "name": "mongofill/mongofill",
     "description": "Polyfill of PECL Mongo extension",
     "minimum-stability": "stable",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mongofill/mongofill",
+    "name": "fiskie/mongofill",
     "description": "Polyfill of PECL Mongo extension",
     "minimum-stability": "stable",
     "license": "MIT",

--- a/src/MongoCursor.php
+++ b/src/MongoCursor.php
@@ -626,9 +626,6 @@ class MongoCursor implements Iterator
      */
     public function current()
     {
-        $this->doQuery();
-        $this->fetchMoreDocumentsIfNeeded();
-
         if (!isset($this->documents[$this->currKey])) {
             return null;
         }
@@ -689,5 +686,8 @@ class MongoCursor implements Iterator
     {
         $this->currKey = 0;
         $this->end = false;
+
+        $this->doQuery();
+        $this->fetchMoreDocumentsIfNeeded();
     }
 }

--- a/src/MongoCursor.php
+++ b/src/MongoCursor.php
@@ -626,6 +626,9 @@ class MongoCursor implements Iterator
      */
     public function current()
     {
+        $this->doQuery();
+        $this->fetchMoreDocumentsIfNeeded();
+
         if (!isset($this->documents[$this->currKey])) {
             return null;
         }

--- a/tests/native/helper.sh
+++ b/tests/native/helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 case "$1" in
 setup)  echo "Creating mongo-php-driver tests environment ..."
-    git clone git@github.com:mongodb/mongo-php-driver.git
+    git clone https://github.com/mongodb/mongo-php-driver-legacy.git mongo-php-driver
     cd mongo-php-driver
     phpize
     ./configure --quiet


### PR DESCRIPTION
In cases where a cursor was empty, a null value would be returned as the only result. This does not match the behaviour of the original Mongo PHP Driver. Simple fix is to call the fetch methods when beginning iteration.

Additionally, a small fix for the helper.sh script since the classic mongo-php-driver repo has since moved.