### PR TITLE
Correctly detect errors and throw exception - change 'err' to '$err'

### DIFF
--- a/src/Mongofill/Socket.php
+++ b/src/Mongofill/Socket.php
@@ -120,8 +120,8 @@ class Socket
 
     protected function throwExceptionIfError(array $record)
     {
-        if (!empty($record['err'])) {
-            throw new MongoCursorException($record['err'], $record['code']);
+        if (!empty($record['$err'])) {
+            throw new MongoCursorException($record['$err'], $record['code']);
         }
     }
 


### PR DESCRIPTION
Error detection is failing as the code is looking for the wrong key in the response record. key should be $err NOT err